### PR TITLE
Update README URLs

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 == U2F for Wordpress
 
-NOTE: Development of this plugin has been (at least temporarily) discontinued since https://github.com/shield-9/u2f-login[a more complete plugin] has appeared.
+NOTE: Development of this plugin has been (at least temporarily) discontinued since https://github.com/shield-9/u2f-login [a more complete plugin] has appeared.
 
 This plugin adds support for the two factor authentication standard U2F.
 

--- a/README
+++ b/README
@@ -14,7 +14,7 @@ The functionality is similar to the U2F (Security Key) support available for Goo
 
 === Installation
 
-. Install the dependencies using http://getcomposer.org[Composer].
+. Install the dependencies using https://getcomposer.org[Composer].
 . Move the wordpress-u2f directory into the `/wp-content/plugins/` directory.
 . Activate the plugin through the 'Plugins' menu in WordPress.
 . Go to _Settings_ -> _U2F_.


### PR DESCRIPTION
Minor changes to the [README](https://github.com/Yubico/wordpress-u2f/blob/master/README): 

**Updated alternative plugin URL**
According to the [linked sheild-9/u2f-login repo](https://github.com/shield-9/u2f-login) (the suggested alternative plugin), it now states that it is not active at that location, and has moved [here](https://github.com/georgestephanis/two-factor).

> <img width="647" alt="screen shot 2016-03-20 at 22 44 47" src="https://cloud.githubusercontent.com/assets/5680603/13907746/63037d58-eeed-11e5-9591-5fc7ba0ff6e0.png">

**Updated Composer URL**
Updated the [Composer link](https://getcomposer.org) to use HTTPS. :lock: :+1:
